### PR TITLE
Small thingys

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Report back device orientation in degrees, 0-360, with 0 being North.
 ####Example
 ```java
 const { DeviceEventEmitter } = require('react-native');
-const ReactNativeHeading = require('react-native-Heading');
+const ReactNativeHeading = require('react-native-heading');
 
 //....
   componentDidMount() {
@@ -25,7 +25,7 @@ const ReactNativeHeading = require('react-native-Heading');
   }
   componentWillUnmount() {
   	ReactNativeHeading.stop();
-  	DeviceEventEmitter.removeListener('headingUpdated');
+  	DeviceEventEmitter.removeAllListeners('headingUpdated');
   }
 //...
 ```


### PR DESCRIPTION
DeviceEventEmitter has no function removeListener(), only removeCurrentListener(), which has to be called inside of an emitting cycle, and removeAllListeners(), which I thought was the most appropriate.
also, one letter was uppercase in the package name